### PR TITLE
Fix regex test resets

### DIFF
--- a/src/playlist/isContainAds.ts
+++ b/src/playlist/isContainAds.ts
@@ -1,5 +1,8 @@
 import { config } from "../misc/state";
 
 export function isContainAds(playlist: string) {
-    return config.adsRegexList.some((regex) => regex.test(playlist));
+    return config.adsRegexList.some((regex) => {
+        regex.lastIndex = 0;
+        return regex.test(playlist);
+    });
 }


### PR DESCRIPTION
## Summary
- reset regex `lastIndex` before calling `.test` so repeated checks work properly